### PR TITLE
Add `tidy.py` script to move SFIII: Second Impact and Third Strike music to correct dirs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You need to have a python 3 available somewhere
 ## Usage
 Download the project.
 
+### Extraction
 Open a command line and execute the following command.
 
 ```
@@ -14,6 +15,13 @@ python extract.py "C:\.....\Street Fighter 30th Anniversary Collection\Bundle" "
 ```
 
 The arguments are 1) the original bundle folder (in your steam directory) 2) the folder where you want stuff to be extracted to.
+
+### Tidy-up
+For some reason, the Second Impact music is in the Third Strike bundle, and the Third Strike music is in the Main bundle. If after extraction, you would like to move these files into the correct games' folder, you can execute the following command:
+
+```
+python tidy.py "C:\...your extraction folder..."
+```
 
 ## Dependency
 `bplist.py` was stolen by the project [bplist-python](https://github.com/farcaller/bplist-python) with a few alterations to make this work.

--- a/tidy.py
+++ b/tidy.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: python tidy.py \"C:\\...your extraction folder...\"")
+    exit(1)
+
+root_dir = sys.argv[1]
+
+if not os.path.exists(root_dir):
+    print("Cant find the extraction folder, are you sure you're using this correctly? Read the README.")
+    exit(2)
+
+main_path = os.path.join(root_dir, "Main")
+second_impact_path = os.path.join(root_dir, "StreetFighterIII_2ndImpact")
+third_strike_path = os.path.join(root_dir, "StreetFighterIII_3rdStrike")
+
+main_files = os.listdir(main_path)
+third_strike_files = os.listdir(third_strike_path)
+
+# Move Second Impact music from Third Strike dir to Second Impact dir.
+for filename in third_strike_files:
+    if filename.startswith("SF3SI") and filename.endswith(".ogg"):
+        print filename
+        old = os.path.join(third_strike_path, filename)
+        new = os.path.join(second_impact_path, filename)
+        os.rename(old, new)
+
+# Move Third Strike music from Main dir to Third Strike dir.
+for filename in main_files:
+    if filename.startswith("SF3TS") and filename.endswith(".ogg"):
+        print filename
+        old = os.path.join(main_path, filename)
+        new = os.path.join(third_strike_path, filename)
+        os.rename(old, new)


### PR DESCRIPTION
Only tested with Python 2 on Mac but hopefully works OK with Python 3 on Windows.